### PR TITLE
Run the publish workflow when a new release is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,8 @@
 name: Publish NuGet Package ⚒️
 
 on:
-  workflow_dispatch:
-
-permissions:
-  pull-requests: "read"
+  release:
+    types: [published]
 
 jobs:
   release:


### PR DESCRIPTION
Change the GitHub actions trigger to run automatically after a new release has been published